### PR TITLE
Plugin API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.24)
 
 project(
 	MapMarkerFramework
-	VERSION 2.1.5
+	VERSION 2.2.0
 	LANGUAGES CXX
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SKSE_SUPPORT_VR OFF)
 
 SKSEPlugin_Add(
 	${PROJECT_NAME}
+	INCLUDE_DIR include
 	SOURCE_DIR src
 	SOURCES
 		.clang-format

--- a/include/MMF/Interfaces.h
+++ b/include/MMF/Interfaces.h
@@ -63,7 +63,7 @@ namespace MMF
 
 		detail::MARKER_INFO proxy_;
 	};
-	static_assert(sizeof(MarkerInfo) == 0x318);
+	static_assert(sizeof(MarkerInfo) == 0x28);
 
 	class MapMarkerInterface
 	{
@@ -90,7 +90,7 @@ namespace MMF
 		 *
 		 * @param[in] a_refr The map marker reference to query.
 		 */
-		[[nodiscard]] std::string_view GetCustomMarkerName(RE::TESObjectREFR* a_refr) const;
+		[[nodiscard]] std::string GetCustomMarkerName(RE::TESObjectREFR* a_refr) const;
 
 		/**
 		 * Get world map marker info for a map marker reference.

--- a/include/MMF/Interfaces.h
+++ b/include/MMF/Interfaces.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include "Stubs.h"
+
+#include "SKSE/Interfaces.h"
+
+#include <string>
+
+namespace RE
+{
+	enum class MARKER_TYPE;
+}
+
+namespace MMF
+{
+	struct MarkerInfo
+	{
+		/**
+		 * Get the vanilla marker index if used.
+		 *
+		 * Undefined behavior if HasExternalIcon() returns true.
+		 */
+		[[nodiscard]] RE::MARKER_TYPE GetVanillaMarker() const;
+
+		/**
+		 * Get whether the marker uses a custom external icon.
+		 */
+		[[nodiscard]] bool HasExternalIcon() const;
+
+		/**
+		 * Get the path to the source SWF for the custom icon.
+		 */
+		[[nodiscard]] std::string GetSourcePath() const;
+
+		/**
+		 * Get the export name of the sprite with the custom icon (discovered).
+		 */
+		[[nodiscard]] std::string GetExportName() const;
+
+		/**
+		 * Get the export name of the sprite with the custom icon (undiscovered).
+		 */
+		[[nodiscard]] std::string GetExportNameUndiscovered() const;
+
+		/**
+		 * Get the scale of the icon.
+		 *
+		 * Always returns 1.0 for vanilla markers.
+		 */
+		[[nodiscard]] float GetIconScale() const;
+
+		/**
+		 * Get whether the marker is hidden from the HUD compass.
+		 */
+		[[nodiscard]] bool IsHiddenFromHUD() const;
+
+		detail::MARKER_INFO proxy_;
+	};
+	static_assert(sizeof(MarkerInfo) == 0x318);
+
+	class MapMarkerInterface
+	{
+	public:
+		enum
+		{
+			kVersion = 1,
+		};
+
+		/**
+		 * Get the version of the interface.
+		 */
+		[[nodiscard]] std::uint32_t Version() const;
+
+		/**
+		 * Get the vanilla marker type from the marker's extra data list.
+		 *
+		 * @param[in] a_refr The map marker reference to query.
+		 */
+		[[nodiscard]] RE::MARKER_TYPE GetVanillaMarkerType(RE::TESObjectREFR* a_refr) const;
+
+		/**
+		 * Get the name used to identify the custom icon if the marker has one.
+		 *
+		 * @param[in] a_refr The map marker reference to query.
+		 */
+		[[nodiscard]] std::string_view GetCustomMarkerName(RE::TESObjectREFR* a_refr) const;
+
+		/**
+		 * Get world map marker info for a map marker reference.
+		 *
+		 * @param[in] a_refr The map marker reference to query.
+		 */
+		[[nodiscard]] MarkerInfo GetMapMarkerInfo(RE::TESObjectREFR* a_refr) const;
+
+		/**
+		 * Get local map marker info for a location.
+		 *
+		 * @param[in] a_location The location to query.
+		 */
+		[[nodiscard]] MarkerInfo GetLocalMarkerInfo(RE::BGSLocation* a_location) const;
+
+	protected:
+		[[nodiscard]] const detail::MapMarkerInterface* GetProxy() const;
+	};
+
+	/**
+	 * Try to get the MapMarkerInterface from a message.
+	 *
+	 * @param[in]  a_msg   The message sent by MapMarkerFramework.
+	 * @param[out] a_intfc The variable to store the interface, if present.
+	 */
+	void QueryMapMarkerInterface(
+		const SKSE::MessagingInterface::Message* a_msg,
+		MapMarkerInterface*& a_intfc);
+}
+
+#include "Interfaces.inl"

--- a/include/MMF/Interfaces.h
+++ b/include/MMF/Interfaces.h
@@ -1,3 +1,10 @@
+/**
+ * @file Interfaces.h
+ *
+ * Copyright (c) Parapets
+ * SPDX-License-Identifier: MIT
+ */
+
 #pragma once
 
 #include "Stubs.h"

--- a/include/MMF/Interfaces.inl
+++ b/include/MMF/Interfaces.inl
@@ -1,3 +1,10 @@
+/**
+ * @file Interfaces.inl
+ *
+ * Copyright (c) Parapets
+ * SPDX-License-Identifier: MIT
+ */
+
 #pragma once
 
 #include "Interfaces.h"

--- a/include/MMF/Interfaces.inl
+++ b/include/MMF/Interfaces.inl
@@ -18,7 +18,8 @@ namespace MMF
 
 	inline bool MarkerInfo::HasExternalIcon() const
 	{
-		return ::strlen(proxy_.SourcePath) && ::strlen(proxy_.ExportName);
+		return proxy_.SourcePath && proxy_.ExportName && ::strlen(proxy_.SourcePath) &&
+			::strlen(proxy_.ExportName);
 	}
 
 	inline std::string MarkerInfo::GetSourcePath() const
@@ -58,8 +59,7 @@ namespace MMF
 		return static_cast<RE::MARKER_TYPE>(markerType);
 	}
 
-	inline std::string_view MapMarkerInterface::GetCustomMarkerName(
-		RE::TESObjectREFR* a_refr) const
+	inline std::string MapMarkerInterface::GetCustomMarkerName(RE::TESObjectREFR* a_refr) const
 	{
 		return GetProxy()->GetCustomMarkerName(a_refr);
 	}

--- a/include/MMF/Interfaces.inl
+++ b/include/MMF/Interfaces.inl
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "Interfaces.h"
+
+namespace MMF
+{
+	inline RE::MARKER_TYPE MarkerInfo::GetVanillaMarker() const
+	{
+		return static_cast<RE::MARKER_TYPE>(proxy_.VanillaMarker);
+	}
+
+	inline bool MarkerInfo::HasExternalIcon() const
+	{
+		return ::strlen(proxy_.SourcePath) && ::strlen(proxy_.ExportName);
+	}
+
+	inline std::string MarkerInfo::GetSourcePath() const
+	{
+		return proxy_.SourcePath;
+	}
+
+	inline std::string MarkerInfo::GetExportName() const
+	{
+		return proxy_.ExportName;
+	}
+
+	inline std::string MarkerInfo::GetExportNameUndiscovered() const
+	{
+		return proxy_.ExportNameUndiscovered;
+	}
+
+	inline float MarkerInfo::GetIconScale() const
+	{
+		return proxy_.IconScale;
+	}
+
+	inline bool MarkerInfo::IsHiddenFromHUD() const
+	{
+		return proxy_.HideFromHUD;
+	}
+
+	inline std::uint32_t MapMarkerInterface::Version() const
+	{
+		return GetProxy()->interfaceVersion;
+	}
+
+	inline RE::MARKER_TYPE MapMarkerInterface::GetVanillaMarkerType(
+		RE::TESObjectREFR* a_refr) const
+	{
+		const auto markerType = GetProxy()->GetVanillaMarkerType(a_refr);
+		return static_cast<RE::MARKER_TYPE>(markerType);
+	}
+
+	inline std::string_view MapMarkerInterface::GetCustomMarkerName(
+		RE::TESObjectREFR* a_refr) const
+	{
+		return GetProxy()->GetCustomMarkerName(a_refr);
+	}
+
+	inline MarkerInfo MapMarkerInterface::GetMapMarkerInfo(RE::TESObjectREFR* a_refr) const
+	{
+		MarkerInfo info{};
+		GetProxy()->GetMapMarkerInfo(a_refr, std::addressof(info.proxy_));
+		return info;
+	}
+
+	inline MarkerInfo MapMarkerInterface::GetLocalMarkerInfo(RE::BGSLocation* a_loc) const
+	{
+		MarkerInfo info{};
+		GetProxy()->GetLocalMarkerInfo(a_loc, std::addressof(info.proxy_));
+		return info;
+	}
+
+	inline const detail::MapMarkerInterface* MapMarkerInterface::GetProxy() const
+	{
+		return reinterpret_cast<const detail::MapMarkerInterface*>(this);
+	}
+
+	inline void QueryMapMarkerInterface(
+		const SKSE::MessagingInterface::Message* a_msg,
+		MapMarkerInterface*& a_intfc)
+	{
+		if (!a_msg || ::strcmp(a_msg->sender, "MapMarkerFramework") != 0 ||
+			a_msg->type != kMapMarkerInterface) {
+			return;
+		}
+
+		auto result = static_cast<MapMarkerInterface*>(a_msg->data);
+
+		if (result && result->Version() > MapMarkerInterface::kVersion) {
+			SKSE::log::warn("interface definition is out of date"sv);
+		}
+
+		a_intfc = result;
+	}
+}

--- a/include/MMF/Stubs.h
+++ b/include/MMF/Stubs.h
@@ -26,14 +26,14 @@ namespace MMF
 	{
 		struct MARKER_INFO
 		{
+			const char* SourcePath;
+			const char* ExportName;
+			const char* ExportNameUndiscovered;
 			std::int32_t VanillaMarker;
-			char SourcePath[260];
-			char ExportName[260];
-			char ExportNameUndiscovered[260];
 			float IconScale;
 			bool HideFromHUD;
 		};
-		static_assert(sizeof(MARKER_INFO) == 0x318);
+		static_assert(sizeof(MARKER_INFO) == 0x28);
 
 		struct MapMarkerInterface
 		{

--- a/include/MMF/Stubs.h
+++ b/include/MMF/Stubs.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstdint>
+
+namespace RE
+{
+	class BGSLocation;
+	class TESObjectREFR;
+}
+
+namespace MMF
+{
+	enum MESSAGE_TYPE : std::uint32_t
+	{
+		kMapMarkerInterface,
+	};
+
+	namespace detail
+	{
+		struct MARKER_INFO
+		{
+			std::int32_t VanillaMarker;
+			char SourcePath[260];
+			char ExportName[260];
+			char ExportNameUndiscovered[260];
+			float IconScale;
+			bool HideFromHUD;
+		};
+		static_assert(sizeof(MARKER_INFO) == 0x318);
+
+		struct MapMarkerInterface
+		{
+			std::uint32_t interfaceVersion;
+			std::uint16_t (*GetVanillaMarkerType)(RE::TESObjectREFR* a_refr);
+			const char* (*GetCustomMarkerName)(RE::TESObjectREFR* a_refr);
+			void (*GetMapMarkerInfo)(RE::TESObjectREFR* a_refr, MARKER_INFO* a_infoOut);
+			void (*GetLocalMarkerInfo)(RE::BGSLocation* a_location, MARKER_INFO* a_infoOut);
+		};
+		static_assert(sizeof(MapMarkerInterface) == 0x28);
+	}
+}

--- a/include/MMF/Stubs.h
+++ b/include/MMF/Stubs.h
@@ -1,3 +1,10 @@
+/**
+ * @file Stubs.h
+ *
+ * Copyright (c) Parapets
+ * SPDX-License-Identifier: MIT
+ */
+
 #pragma once
 
 #include <cstdint>

--- a/src/MMF/MapMarkerInterface.cpp
+++ b/src/MMF/MapMarkerInterface.cpp
@@ -1,0 +1,128 @@
+#include "MapMarkerInterface.h"
+#include "main/ImportManager.h"
+#include "main/LocalMapManager.h"
+#include "main/MapConfigLoader.h"
+
+namespace MMF::Impl
+{
+	void MapMarkerInterface::Dispatch()
+	{
+		SKSE::GetMessagingInterface()
+			->Dispatch(kMapMarkerInterface, Get(), sizeof(detail::MapMarkerInterface), nullptr);
+	}
+
+	detail::MapMarkerInterface* MapMarkerInterface::Get()
+	{
+		static detail::MapMarkerInterface intfc{
+			.interfaceVersion = InterfaceVersion,
+			.GetCustomMarkerName = &GetCustomMarkerName,
+			.GetMapMarkerInfo = &GetMapMarkerInfo,
+			.GetLocalMarkerInfo = &GetLocalMarkerInfo,
+		};
+
+		return std::addressof(intfc);
+	}
+
+	std::uint16_t MapMarkerInterface::GetVanillaMarkerType(RE::TESObjectREFR* a_refr)
+	{
+		if (!a_refr) {
+			return 0;
+		}
+
+		if (auto extraMapMarker = a_refr->extraList.GetByType<RE::ExtraMapMarker>()) {
+			if (auto data = extraMapMarker->mapData) {
+				return data->type.underlying();
+			}
+		}
+
+		return 0;
+	}
+
+	const char* MapMarkerInterface::GetCustomMarkerName(RE::TESObjectREFR* a_refr)
+	{
+		const auto configLoader = MapConfigLoader::GetSingleton();
+		const auto& mapMarker = configLoader->GetMapMarker(a_refr);
+		if (std::holds_alternative<std::string>(mapMarker)) {
+			return std::get<std::string>(mapMarker).data();
+		}
+
+		return "";
+	}
+
+	void MapMarkerInterface::GetMapMarkerInfo(
+		RE::TESObjectREFR* a_refr,
+		detail::MARKER_INFO* a_infoOut)
+	{
+		if (!a_infoOut) {
+			return;
+		}
+
+		a_infoOut->VanillaMarker = GetVanillaMarkerType(a_refr);
+		std::memset(a_infoOut->SourcePath, '\0', 260);
+		std::memset(a_infoOut->ExportName, '\0', 260);
+		std::memset(a_infoOut->ExportNameUndiscovered, '\0', 260);
+		a_infoOut->IconScale = 1.0f;
+		a_infoOut->HideFromHUD = false;
+
+		const auto configLoader = MapConfigLoader::GetSingleton();
+		const auto importManager = ImportManager::GetSingleton();
+
+		const auto& mapMarker = configLoader->GetMapMarker(a_refr);
+		if (std::holds_alternative<RE::MARKER_TYPE>(mapMarker)) {
+			a_infoOut->VanillaMarker = static_cast<std::int32_t>(
+				std::get<RE::MARKER_TYPE>(mapMarker));
+		}
+		else if (std::holds_alternative<std::string>(mapMarker)) {
+			const auto index = configLoader->GetIconIndex(std::get<std::string>(mapMarker));
+			const auto iconInfo = importManager->GetIconInfo(index);
+			SetIconInfo(iconInfo, a_infoOut);
+		}
+	}
+
+	void MapMarkerInterface::GetLocalMarkerInfo(
+		RE::BGSLocation* a_location,
+		detail::MARKER_INFO* a_infoOut)
+	{
+		if (!a_infoOut) {
+			return;
+		}
+
+		a_infoOut->VanillaMarker = static_cast<std::int32_t>(RE::MARKER_TYPE::kDoor);
+		std::memset(a_infoOut->SourcePath, '\0', 260);
+		std::memset(a_infoOut->ExportName, '\0', 260);
+		std::memset(a_infoOut->ExportNameUndiscovered, '\0', 260);
+		a_infoOut->IconScale = 1.0f;
+		a_infoOut->HideFromHUD = false;
+
+		const auto configLoader = MapConfigLoader::GetSingleton();
+		const auto importManager = ImportManager::GetSingleton();
+
+		const auto& mapMarker = configLoader->GetLocalMarker(a_location);
+		if (std::holds_alternative<RE::MARKER_TYPE>(mapMarker)) {
+			a_infoOut->VanillaMarker = static_cast<std::int32_t>(
+				std::get<RE::MARKER_TYPE>(mapMarker));
+		}
+		else if (std::holds_alternative<std::string>(mapMarker)) {
+			const auto index = configLoader->GetIconIndex(std::get<std::string>(mapMarker));
+			const auto iconInfo = importManager->GetIconInfo(index);
+			SetIconInfo(iconInfo, a_infoOut);
+		}
+	}
+
+	void MapMarkerInterface::SetIconInfo(const IconInfo* a_info, detail::MARKER_INFO* a_infoOut)
+	{
+		assert(a_infoOut);
+
+		if (a_info) {
+			::strcpy_s(a_infoOut->SourcePath, 260, a_info->SourcePath.c_str());
+			::strcpy_s(a_infoOut->ExportName, 260, a_info->ExportName.c_str());
+			::strcpy_s(
+				a_infoOut->ExportNameUndiscovered,
+				260,
+				a_info->ExportNameUndiscovered.c_str());
+
+			a_infoOut->IconScale = a_info->IconScale;
+			a_infoOut->HideFromHUD = a_info->HideFromHUD;
+		}
+	}
+}

--- a/src/MMF/MapMarkerInterface.cpp
+++ b/src/MMF/MapMarkerInterface.cpp
@@ -58,9 +58,9 @@ namespace MMF::Impl
 		}
 
 		a_infoOut->VanillaMarker = GetVanillaMarkerType(a_refr);
-		std::memset(a_infoOut->SourcePath, '\0', 260);
-		std::memset(a_infoOut->ExportName, '\0', 260);
-		std::memset(a_infoOut->ExportNameUndiscovered, '\0', 260);
+		a_infoOut->SourcePath = nullptr;
+		a_infoOut->ExportName = nullptr;
+		a_infoOut->ExportNameUndiscovered = nullptr;
 		a_infoOut->IconScale = 1.0f;
 		a_infoOut->HideFromHUD = false;
 
@@ -88,9 +88,9 @@ namespace MMF::Impl
 		}
 
 		a_infoOut->VanillaMarker = static_cast<std::int32_t>(RE::MARKER_TYPE::kDoor);
-		std::memset(a_infoOut->SourcePath, '\0', 260);
-		std::memset(a_infoOut->ExportName, '\0', 260);
-		std::memset(a_infoOut->ExportNameUndiscovered, '\0', 260);
+		a_infoOut->SourcePath = nullptr;
+		a_infoOut->ExportName = nullptr;
+		a_infoOut->ExportNameUndiscovered = nullptr;
 		a_infoOut->IconScale = 1.0f;
 		a_infoOut->HideFromHUD = false;
 
@@ -114,13 +114,9 @@ namespace MMF::Impl
 		assert(a_infoOut);
 
 		if (a_info) {
-			::strcpy_s(a_infoOut->SourcePath, 260, a_info->SourcePath.c_str());
-			::strcpy_s(a_infoOut->ExportName, 260, a_info->ExportName.c_str());
-			::strcpy_s(
-				a_infoOut->ExportNameUndiscovered,
-				260,
-				a_info->ExportNameUndiscovered.c_str());
-
+			a_infoOut->SourcePath = a_info->SourcePath.data();
+			a_infoOut->ExportName = a_info->ExportName.data();
+			a_infoOut->ExportNameUndiscovered = a_info->ExportNameUndiscovered.data();
 			a_infoOut->IconScale = a_info->IconScale;
 			a_infoOut->HideFromHUD = a_info->HideFromHUD;
 		}

--- a/src/MMF/MapMarkerInterface.h
+++ b/src/MMF/MapMarkerInterface.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "MMF/Stubs.h"
+#include "main/ImportData.h"
+
+namespace MMF::Impl
+{
+	namespace MapMarkerInterface
+	{
+		constexpr std::uint32_t InterfaceVersion = 1;
+
+		void Dispatch();
+
+		detail::MapMarkerInterface* Get();
+
+		std::uint16_t GetVanillaMarkerType(RE::TESObjectREFR* a_refr);
+
+		const char* GetCustomMarkerName(RE::TESObjectREFR* a_refr);
+
+		void GetMapMarkerInfo(RE::TESObjectREFR* a_refr, detail::MARKER_INFO* a_infoOut);
+
+		void GetLocalMarkerInfo(RE::BGSLocation* a_location, detail::MARKER_INFO* a_infoOut);
+
+		void SetIconInfo(const IconInfo* a_info, detail::MARKER_INFO* a_infoOut);
+	}
+}

--- a/src/main/ImportManager.cpp
+++ b/src/main/ImportManager.cpp
@@ -32,6 +32,16 @@ void ImportManager::HideFromHUD(RE::MARKER_TYPE a_markerType)
 	_hideFromHUD.insert(a_markerType);
 }
 
+const IconInfo* ImportManager::GetIconInfo(std::int32_t a_index) const
+{
+	if (a_index >= 0 && a_index < _customIcons.size()) {
+		return &_customIcons[a_index];
+	}
+	else {
+		return nullptr;
+	}
+}
+
 void ImportManager::InstallHooks()
 {
 	bool success = Patch::WriteLoadHUDPatch(LoadMovie_HUD, _LoadMovie_HUD);

--- a/src/main/ImportManager.h
+++ b/src/main/ImportManager.h
@@ -24,6 +24,8 @@ public:
 
 	void HideFromHUD(RE::MARKER_TYPE a_markerType);
 
+	const IconInfo* GetIconInfo(std::int32_t a_index) const;
+
 private:
 	ImportManager() = default;
 

--- a/src/main/MapConfigLoader.h
+++ b/src/main/MapConfigLoader.h
@@ -3,6 +3,10 @@
 class MapConfigLoader
 {
 public:
+	using MapMarker = std::variant<RE::MARKER_TYPE, std::string>;
+	inline static const MapMarker NoMarker = RE::MARKER_TYPE::kNone;
+	inline static const MapMarker DoorMarker = RE::MARKER_TYPE::kDoor;
+
 	~MapConfigLoader() = default;
 	MapConfigLoader(const MapConfigLoader&) = delete;
 	MapConfigLoader(MapConfigLoader&&) = delete;
@@ -14,9 +18,13 @@ public:
 	void LoadAll();
 	void UpdateMarkers(std::uint32_t a_customIconIndex) const;
 
-private:
-	using MapMarker = std::variant<RE::MARKER_TYPE, std::string>;
+	const MapMarker& GetMapMarker(RE::TESObjectREFR* a_refr) const;
 
+	const MapMarker& GetLocalMarker(RE::BGSLocation* a_location) const;
+
+	std::int32_t GetIconIndex(const std::string& a_name) const;
+
+private:
 	MapConfigLoader() = default;
 
 	void LoadFromFile(

--- a/src/main/SKSEPlugin.cpp
+++ b/src/main/SKSEPlugin.cpp
@@ -1,6 +1,7 @@
 #include "DiscoveryMusicManager.h"
 #include "ImportManager.h"
 #include "LocalMapManager.h"
+#include "MMF/MapMarkerInterface.h"
 #include "MapConfigLoader.h"
 #include "Settings.h"
 #include "VendorManager.h"
@@ -71,6 +72,7 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* a_s
 			case SKSE::MessagingInterface::kDataLoaded:
 				MapConfigLoader::GetSingleton()->LoadAll();
 				VendorManager::GetSingleton()->Load();
+				MMF::Impl::MapMarkerInterface::Dispatch();
 				break;
 			}
 		});


### PR DESCRIPTION
Usage:
```c++
class PluginAPIStorage
{
public:
	static PluginAPIStorage& get()
	{
		static PluginAPIStorage singleton{};
		return singleton;
	}

	MMF::MapMarkerInterface* comap;
};

MMF::MapMarkerInterface* GetCoMAPInterface()
{
	return PluginAPIStorage::get().comap;
}

extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* a_skse)
{
	InitializeLog();
	logger::info("{} v{}"sv, Plugin::NAME, Plugin::VERSION.string());

	SKSE::Init(a_skse);

	SKSE::GetMessagingInterface()->RegisterListener("MapMarkerFramework", [](auto msg)
	{
		MMF::QueryMapMarkerInterface(msg, PluginAPIStorage::get().comap);
	});

	return true;
}

```